### PR TITLE
fix: update display when deleting letters

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -36,6 +36,10 @@ function shadeKeyBoard(letter, color) {
 function deleteLetter() {
     currentGuess.pop();
     nextLetter -= 1;
+    const row = document.getElementsByClassName('letter-row')[6 - guessesRemaining];
+    const box = row.children[nextLetter];
+    box.textContent = '';
+    box.classList.remove('filled-box');
 }
 
 function checkGuess() {


### PR DESCRIPTION
This PR resolves issue [#3](https://github.com/up-csi/innov-internship-2526A-Team-2/issues/3). The PR does the following:
- Update the display to show that a letter is deleted when `backspace` is pressed
- Remove the black outline that is present when a box is occupied by a letter when `backspace` is pressed